### PR TITLE
Replace discord server link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ aux_links:
   Home: https://sidestore.io
   GitHub: https://github.com/sidestore
   Patreon: https://www.patreon.com/sidestore
-  Discord: https://discord.gg/altstore-delta-625714187078860810
+  Discord: https://discord.gg/RgpFBX3Q3k
   Twitter: https://twitter.com/sidestore_io
 
 favicon_ico: "/assets/icons/favicon.ico"


### PR DESCRIPTION
The discord server link in the header pointed to the "AltStore/Delta" server, this pr changes it to the "JitStreamer" server (https://discord.gg/RgpFBX3Q3k).