### PR TITLE
misc: add docs-maintainers as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 *       @JoeMatt @lonkelle @nythepegasus @Spidy123222 @SternXD
+*       @SideStore/docs-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @JoeMatt @lonkelle @nythepegasus @Spidy123222 @SternXD @SideStore/docs-maintainers
+*       @JoeMatt @lonkelle @nythepegasus @Spidy123222 @SternXD @SideStore/docs-maintainer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-*       @JoeMatt @lonkelle @nythepegasus @Spidy123222 @SternXD
-*       @SideStore/docs-maintainers
+*       @JoeMatt @lonkelle @nythepegasus @Spidy123222 @SternXD @SideStore/docs-maintainers


### PR DESCRIPTION
Adds @SideStore/docs-maintainer as CODEOWNERS for the SideStore-Docs Repository