### PR TITLE
Fix EN typos

### DIFF
--- a/docs/contributing/contributing.mdx
+++ b/docs/contributing/contributing.mdx
@@ -93,7 +93,7 @@ Examples:
     export BUILD_CONFIG=Debug;make build fakesign ipa
 ```
 
-By default sidestore will build for its default bundleIdentifier `com.SideStore.SideStore` but if you need to set a custom bundleID for commandline builds, once can do so by exporting `BUNDLE_ID_SUFFIX` env var:
+By default SideStore will build for its default bundleIdentifier `com.SideStore.SideStore` but if you need to set a custom bundleID for commandline builds, once can do so by exporting `BUNDLE_ID_SUFFIX` env var:
 
 ```sh
     # stable release build

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -124,11 +124,11 @@ Don't panic! Re-sideload the apps without removing them from your device, and yo
 
 ### I'm unable to select my pairing file with any file type
 
-Make sure your pairing file's extension ends with `.mobiledevicepairing` or `.plist`. If it doesn't, double check to see if you had zipped your pairing file before sending it to your phone. Failing to do so may lead to the file being corrupted during transport. Also, when signing Sidestore with a certificate, you won't be able to select the pairing file from within app. You can try moving the pairing file to the root directory of the SideStore folder in the Files app in "On My iPhone/iPad", and naming it `ALTPairingFile.mobiledevicepairing`. If you do not see the Sidestore folder in the files app, connect your phone to your computer, and you can drag and drop the pairing file to the files of the Sidestore app. Ensure to change it to name mentioned above. Note that it is case sensitive.
+Make sure your pairing file's extension ends with `.mobiledevicepairing` or `.plist`. If it doesn't, double check to see if you had zipped your pairing file before sending it to your phone. Failing to do so may lead to the file being corrupted during transport. Also, when signing SideStore with a certificate, you won't be able to select the pairing file from within app. You can try moving the pairing file to the root directory of the SideStore folder in the Files app in "On My iPhone/iPad", and naming it `ALTPairingFile.mobiledevicepairing`. If you do not see the SideStore folder in the files app, connect your phone to your computer, and you can drag and drop the pairing file to the files of the SideStore app. Ensure to change it to name mentioned above. Note that it is case sensitive.
 
 ### Cannot start DebugServer
 
-There is times when the Debugserver doesn't work. However, there is a fix you can try:
+There is times when the DebugServer doesn't work. However, there is a fix you can try:
 
 **Make a new pairing file**
 

--- a/docs/installation/linux.mdx
+++ b/docs/installation/linux.mdx
@@ -8,7 +8,7 @@ Before you start, make sure to have all steps completed found in the [prerequisi
 
 1. Ensure you have usbmuxd installed and updated by running `sudo apt install -y usbmuxd` in the Linux terminal.
 2. Install either Docker or Podman on your machine. 
-2. Plug in your secondary iDevice. If you recieve a prompt, select "trust" and enter your passcode.
+2. Plug in your secondary iDevice. If you receive a prompt, select "trust" and enter your passcode.
 
 3. Now, run Altcon with Docker or Podman using the following command (may require `sudo`):
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -15,7 +15,7 @@ sidebar_position: 6
 - Added support for importing/exporting your Apple ID's certificate for use with multiple devices, instructions to utilize this [here](https://github.com/SideStore/SideStore/pull/1008#issue-3138680291)
 - Adds url scheme/allow exporting certificate (to LiveContainer)
 - Fix issue where installing apps would get stuck around 75%
-- Add option to resuse the main App ID profile for extensions instead of removing/registering them (only one app id/app)
+- Add option to reuse the main App ID profile for extensions instead of removing/registering them (only one app id/app)
 - General type fixes and visual updates
 
 ### What's Changed:

--- a/docs/troubleshooting/common-issues.mdx
+++ b/docs/troubleshooting/common-issues.mdx
@@ -55,6 +55,6 @@ If the above doesn't work, do the following:
 3. Import your pairing file and login. (It will give you a prompt to refresh SideStore, select no)
 4. Install the `sidestore.ipa` file to your device
 5. Import the `sidestore.ipa` file into SideStore like how you would install any other IPA
-6. This will allow Sidestore to do a clean refresh, and hopefully fix the issue
+6. This will allow SideStore to do a clean refresh, and hopefully fix the issue
 
 

--- a/docs/troubleshooting/error-codes.mdx
+++ b/docs/troubleshooting/error-codes.mdx
@@ -63,7 +63,7 @@ This means the app you're trying to install is not a standard .ipa. Try download
 
 `SideStore.OperationError 1008`
 
-This means an internal error occured and SideStore couldn't provide the necessary information to perform the requested task. Please try again and check our [Troubleshooting Guide](./) for additional help. You can reach out to us directly if the issue persists at our Discord server.
+This means an internal error occurred and SideStore couldn't provide the necessary information to perform the requested task. Please try again and check our [Troubleshooting Guide](./) for additional help. You can reach out to us directly if the issue persists at our Discord server.
 
 #### (1009) You cannot register more than 10 App IDs within a 7-day period.
 
@@ -75,7 +75,7 @@ This means that you have reached the maximum amount of App IDs available. Apps I
 
 `SideStore.OperationError 1010`
 
-This means an internal error occured and SideStore is unable to fetch changes for any AltSources you've added. Please try again and check our [Troubleshooting Guide](./) for additional help. You can reach out to us directly at our Discord server if the issue persists.
+This means an internal error occurred and SideStore is unable to fetch changes for any AltSources you've added. Please try again and check our [Troubleshooting Guide](./) for additional help. You can reach out to us directly at our Discord server if the issue persists.
 
 #### (1011) SideStore was denied permission to launch the app.
 
@@ -99,7 +99,7 @@ Please make sure you are on the same Wi-Fi as your computer running SideJITServe
 
 `SideStore.OperationError 1412`
 
-Your device was unable to recieve data from a V3 anisette server. Please try again, or switch anisette servers.
+Your device was unable to receive data from a V3 anisette server. Please try again, or switch anisette servers.
 
 #### (1414) No Wi-Fi/StosVPN.
 

--- a/docs/troubleshooting/troubleshooting.mdx
+++ b/docs/troubleshooting/troubleshooting.mdx
@@ -14,7 +14,7 @@ description: A guide to troubleshooting SideStore in situations without an error
 2. **Use Another Apple ID**: Try using another Apple ID. If needed, you can [create a new Apple ID](https://appleid.apple.com/account#!\&page=create) specifically for SideStore use for free.
 
 #### Windows Instructions
-1. **Trust Device**: After connecting your iOS device to your Windows computer, ensure you have slected “Trust” on both your computer and iOS device. You can verify this by:
+1. **Trust Device**: After connecting your iOS device to your Windows computer, ensure you have selected “Trust” on both your computer and iOS device. You can verify this by:
    - Opening iTunes and checking if a dialog box appears asking if you want to trust the device.
 2. **Run AltServer as Administrator**: Right-click on AltServer and select “Run as Administrator” to ensure proper permissions.
 3. **Use Another Apple ID**: Try using another Apple ID. If needed, you can [create a new Apple ID](https://appleid.apple.com/account#!\&page=create) specifically for SideStore for free.
@@ -70,7 +70,7 @@ Another common issue during sign-in is not receiving a verification code when us
 
 1. Enable Airplane Mode and connect to a stable Wi-Fi network.
 2. Ensure that Apple domains and the domain for your anisette server are not restricted. Check the following:
-   - Turn off any DNS servers blocking domains such as `oscp.apple.com`
+   - Turn off any DNS servers blocking domains such as `ocsp.apple.com`
    - Disconnect from school/work Wi-Fi, try connecting to a restriction-free network.
 3. Verify VPN is connected in StosVPN.
 4. Turn StosVPN off, then back on, and wait a few seconds in SideStore before trying to refresh.
@@ -80,7 +80,7 @@ Another common issue during sign-in is not receiving a verification code when us
 
 ## Cannot Choose Pairing File
 
-### If you are unable to select a pairing file in Sidestore, follow these steps to resolve the issue:
+### If you are unable to select a pairing file in SideStore, follow these steps to resolve the issue:
 
 1. **Reimport Pairing File**: Use idevice pair to regenerate and import your pairing file to your device. If idevice pair doesn't work, try jitterbugpair and follow the steps below.
 2. **Check File Extension**: Make sure your pairing file's extension ends with `.mobiledevicepairing` or `.plist`. If it doesn't, double-check to see if you had zipped your pairing file before sending it to your phone. Failing to do so may lead to the file being corrupted during transport.


### PR DESCRIPTION
Note: In `troubleshooting.mdx` the domain you don't want to block is `ocsp.apple.com` and not `oscp.apple.com`