### PR TITLE
Add Chromebook installation instructions

### DIFF
--- a/docs/installation/prerequisites.mdx
+++ b/docs/installation/prerequisites.mdx
@@ -58,7 +58,7 @@ Now, follow the instructions to install [iloader](https://iloader.app) correspon
     1. Download and install `usbmuxd`. It may be preinstalled with your distribution, otherwise you can install it with your package manager: a Google search for "install usbmuxd [distribution name]" might help you.
     2. Download and install iloader for your distribution. It is available as a [DEB](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-amd64.deb) for Debian/Ubuntu, [RPM](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-x86_64.rpm) for Fedora/openSUSE, and as an [AppImage](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-amd64.AppImage) for others. Additionally, for ARM processors there are also [DEB](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-arm64.deb), [RPM](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-aarch64.rpm), and [AppImage](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-aarch64.AppImage) builds. (There are also community-maintained packages, such as [this one on the Arch Linux AUR](https://aur.archlinux.org/packages/iloader-bin), but please know that we cannot guarantee their safety or security. You should always do your due diligence before installing unknown packages onto your system.)
   </TabItem>
-  <TabItem value="linux" label="Chromebook">
+  <TabItem value="chromebook" label="Chromebook">
     :::warning
     **This will not work with enrolled Chromebooks, and may not work with old Chromebooks.** Usually enrolled Chromebooks have `Linux development environment` disabled, or for old Chromebooks, they do not provide such options.
     :::

--- a/docs/installation/prerequisites.mdx
+++ b/docs/installation/prerequisites.mdx
@@ -58,4 +58,16 @@ Now, follow the instructions to install [iloader](https://iloader.app) correspon
     1. Download and install `usbmuxd`. It may be preinstalled with your distribution, otherwise you can install it with your package manager: a Google search for "install usbmuxd [distribution name]" might help you.
     2. Download and install iloader for your distribution. It is available as a [DEB](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-amd64.deb) for Debian/Ubuntu, [RPM](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-x86_64.rpm) for Fedora/openSUSE, and as an [AppImage](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-amd64.AppImage) for others. Additionally, for ARM processors there are also [DEB](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-arm64.deb), [RPM](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-aarch64.rpm), and [AppImage](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-aarch64.AppImage) builds. (There are also community-maintained packages, such as [this one on the Arch Linux AUR](https://aur.archlinux.org/packages/iloader-bin), but please know that we cannot guarantee their safety or security. You should always do your due diligence before installing unknown packages onto your system.)
   </TabItem>
+  <TabItem value="linux" label="Chromebook">
+    :::warning
+    **This will not work with enrolled Chromebooks, and may not work with old Chromebooks.** Usually enrolled Chromebooks have "Linux Dev Environment" disabled, or old Chromebooks don't provide such options.
+    :::
+
+    1. Enable `Linux development environment`. You can read the [Set up Linux on your Chromebook](https://support.google.com/chromebook/answer/9145439) guide by Google to see how to set it up, following the `Turn on Linux` steps.
+    2. Ensure all packages are updated by opening the Terminal, entering: `sudo apt-get update && sudo apt-get dist-upgrade`
+    3. Open the Files app, right click on the `Downloads` folder and click `Share with Linux`.
+    4. Download and install `usbmuxd` and `fuse`. It may be preinstalled with your distribution, otherwise you can install it with your package manager: `sudo apt-get install usbmuxd fuse`
+    5. Download and install iloader. It is available as an [AppImage](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-aarch64.AppImage). Download the file to your Downloads folder.
+    6. 
+  </TabItem>
 </Tabs>

--- a/docs/installation/prerequisites.mdx
+++ b/docs/installation/prerequisites.mdx
@@ -66,7 +66,7 @@ Now, follow the instructions to install [iloader](https://iloader.app) correspon
     1. Enable `Linux development environment`. You can read the [Set up Linux on your Chromebook](https://support.google.com/chromebook/answer/9145439) guide by Google to see how to set it up, following the `Turn on Linux` steps.
     2. Ensure all packages are updated by opening the Terminal, running the following command: `sudo apt-get update && sudo apt-get dist-upgrade`
     3. Open the Files app, right click on the `Downloads` folder in the left sidebar, and click `Share with Linux`. (It will be shared in `/mnt/chromeos/MyFiles/Downloads`)
-    4. Download and install `usbmuxd` and `fuse`. It may be preinstalled with your distribution, otherwise you can install it with your package manager: `sudo apt-get install usbmuxd fuse`
+    4. Download and install `usbmuxd` and `fuse`. You can install it with your package manager by running the following command in the Terminal: `sudo apt-get install usbmuxd fuse`
     5. Download and install iloader. It is available as an [AppImage](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-aarch64.AppImage). Download the file to your Downloads folder.
     6. If `usbmuxd` isn't already started, run the following command in the Terminal: `sudo systemctl restart usbmuxd`
     7. Navigate to `Manage USB devices` (in **Settings** -> **About ChromeOS** -> **Developers** -> **Linux development environment**), then connect your iPhone, iPad, or iPod touch (iDevice) to your Chromebook via a USB cable. As soon as you see the device, **quickly enable it from the list**. If you are prompted on your iDevice, trust the computer and enter your passcode.

--- a/docs/installation/prerequisites.mdx
+++ b/docs/installation/prerequisites.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 ## Requirements
 To install SideStore, you will need:
 - An iPhone, iPad, or iPod touch [with a passcode](https://support.apple.com/en-us/119586) running iOS/iPadOS 15.0 or higher
-- A computer running Windows 8 or higher, macOS High Sierra or higher, or an up-to-date Linux distribution; only for initial install
+- A computer running Windows 8 or higher, macOS High Sierra or higher, an up-to-date Linux distribution, or a recent unenrolled Chromebook; only for initial install
 - An Apple Account (also called an Apple ID)
 - A Wi-Fi connection
 - Some time! This is a quick and easy process, but you should leave time for [troubleshooting](/docs/troubleshooting)
@@ -68,6 +68,5 @@ Now, follow the instructions to install [iloader](https://iloader.app) correspon
     3. Open the Files app, right click on the `Downloads` folder and click `Share with Linux`.
     4. Download and install `usbmuxd` and `fuse`. It may be preinstalled with your distribution, otherwise you can install it with your package manager: `sudo apt-get install usbmuxd fuse`
     5. Download and install iloader. It is available as an [AppImage](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-aarch64.AppImage). Download the file to your Downloads folder.
-    6. 
   </TabItem>
 </Tabs>

--- a/docs/installation/prerequisites.mdx
+++ b/docs/installation/prerequisites.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 ## Requirements
 To install SideStore, you will need:
 - An iPhone, iPad, or iPod touch [with a passcode](https://support.apple.com/en-us/119586) running iOS/iPadOS 15.0 or higher
-- A computer running Windows 8 or higher, macOS High Sierra or higher, an up-to-date Linux distribution, or a recent unenrolled Chromebook; only for initial install
+- A computer running Windows 8 or higher, macOS High Sierra or higher, an up-to-date Linux distribution, or a recent un-enrolled Chromebook; only for initial install
 - An Apple Account (also called an Apple ID)
 - A Wi-Fi connection
 - Some time! This is a quick and easy process, but you should leave time for [troubleshooting](/docs/troubleshooting)
@@ -60,7 +60,7 @@ Now, follow the instructions to install [iloader](https://iloader.app) correspon
   </TabItem>
   <TabItem value="linux" label="Chromebook">
     :::warning
-    **This will not work with enrolled Chromebooks, and may not work with old Chromebooks.** Usually enrolled Chromebooks have "Linux Dev Environment" disabled, or old Chromebooks don't provide such options.
+    **This will not work with enrolled Chromebooks, and may not work with old Chromebooks.** Usually enrolled Chromebooks have `Linux development environment` disabled, or for old Chromebooks, they do not provide such options.
     :::
 
     1. Enable `Linux development environment`. You can read the [Set up Linux on your Chromebook](https://support.google.com/chromebook/answer/9145439) guide by Google to see how to set it up, following the `Turn on Linux` steps.

--- a/docs/installation/prerequisites.mdx
+++ b/docs/installation/prerequisites.mdx
@@ -67,7 +67,7 @@ Now, follow the instructions to install [iloader](https://iloader.app) correspon
     2. Ensure all packages are updated by opening the Terminal, running the following command: `sudo apt-get update && sudo apt-get dist-upgrade`
     3. Open the Files app, right click on the `Downloads` folder in the left sidebar, and click `Share with Linux`. (It will be shared in `/mnt/chromeos/MyFiles/Downloads`)
     4. Download and install `usbmuxd` and `fuse`. You can install it with your package manager by running the following command in the Terminal: `sudo apt-get install usbmuxd fuse`
-    5. Download and install iloader. It is available as an AppImage. To know which version to download, determine your Chromebook's architecture using `uname -m`. If it reports x86_64, download the `amd64` version here: https://github.com/nab138/iloader/releases/download/v2.2.5/iloader-linux-amd64.AppImage. Otherwise if it reports `aarch64`, download the `aarch64` version here: https://github.com/nab138/iloader/releases/latest/download/iloader-linux-aarch64.AppImage. Download the file to your Downloads folder.
+    5. Download and install iloader. It is available as an AppImage. To know which version to download, determine your Chromebook's architecture using `uname -m`. If the command outputs `x86_64`, download the `amd64` version here: https://github.com/nab138/iloader/releases/download/v2.2.5/iloader-linux-amd64.AppImage. Otherwise if it outputs `aarch64`, download the `aarch64` version here: https://github.com/nab138/iloader/releases/latest/download/iloader-linux-aarch64.AppImage. Download the file to your Downloads folder.
     6. If `usbmuxd` isn't already started, run the following command in the Terminal: `sudo systemctl restart usbmuxd`.
     7. Navigate to `Manage USB devices` (in **Settings** -> **About ChromeOS** -> **Developers** -> **Linux development environment**), then connect your iPhone, iPad, or iPod touch (iDevice) to your Chromebook via a USB cable. As soon as you see the device, **quickly enable it from the list**. If you are prompted on your iDevice, trust the computer and enter your passcode.
     :::note
@@ -83,7 +83,7 @@ Now, follow the instructions to install [iloader](https://iloader.app) correspon
     ```
     The exact device name and bus/device numbers may vary, but they are not significant.
     :::
-    9. Run the following command in the Terminal to allow iloader to be executable, and to launch iloader (ensure the filename matches what was downloaded, if it is `amd64`, replace `aarch64` with `amd64`):
+    9. Run the following command in the Terminal to allow iloader to be executable, and to launch iloader (ensure the filename matches what was downloaded, if the file name contains `amd64`, replace `aarch64` with `amd64`):
     ```
     cd /mnt/chromeos/MyFiles/Downloads
     chmod +x iloader-linux-aarch64.AppImage

--- a/docs/installation/prerequisites.mdx
+++ b/docs/installation/prerequisites.mdx
@@ -60,13 +60,34 @@ Now, follow the instructions to install [iloader](https://iloader.app) correspon
   </TabItem>
   <TabItem value="chromebook" label="Chromebook">
     :::warning
-    **This will not work with enrolled Chromebooks, and may not work with old Chromebooks.** Usually enrolled Chromebooks have `Linux development environment` disabled, or for old Chromebooks, they do not provide such options.
+    **This will not work with enrolled Chromebooks if the Administrator disabled it, and may not work with old Chromebooks.** Usually enrolled Chromebooks have `Linux development environment` disabled, or for old Chromebooks, they do not provide such options.
     :::
 
     1. Enable `Linux development environment`. You can read the [Set up Linux on your Chromebook](https://support.google.com/chromebook/answer/9145439) guide by Google to see how to set it up, following the `Turn on Linux` steps.
-    2. Ensure all packages are updated by opening the Terminal, entering: `sudo apt-get update && sudo apt-get dist-upgrade`
-    3. Open the Files app, right click on the `Downloads` folder and click `Share with Linux`.
+    2. Ensure all packages are updated by opening the Terminal, running the following command: `sudo apt-get update && sudo apt-get dist-upgrade`
+    3. Open the Files app, right click on the `Downloads` folder in the left sidebar, and click `Share with Linux`. (It will be shared in `/mnt/chromeos/MyFiles/Downloads`)
     4. Download and install `usbmuxd` and `fuse`. It may be preinstalled with your distribution, otherwise you can install it with your package manager: `sudo apt-get install usbmuxd fuse`
     5. Download and install iloader. It is available as an [AppImage](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-aarch64.AppImage). Download the file to your Downloads folder.
+    6. If `usbmuxd` isn't already started, run the following command in the Terminal: `sudo systemctl restart usbmuxd`
+    7. Navigate to `Manage USB devices` (in **Settings** -> **About ChromeOS** -> **Developers** -> **Linux development environment**), then connect your iPhone, iPad, or iPod touch (iDevice) to your Chromebook via a USB cable. As soon as you see the device, **quickly enable it from the list**. If you are prompted on your iDevice, trust the computer and enter your passcode.
+    :::note
+    **Enabling the iDevice __quickly__ in Manage USB devices is necessary** due to a bug with the `Linux development environment`. ChromeOS automatically claims the iDevice (which is why it appears in the Files app), preventing the Linux container from seeing it. Manually enabling it in **Manage USB devices** quickly before ChromeOS claims the iDevice will pass control to the container instead. You can follow **Step 8** to verify the container sees the iDevice.
+    :::
+    8. Verify the `Linux development environment` recognizes your iDevice by running `lsusb` in the Terminal. Your iDevice should appear in the list. If it doesn't, try unplugging, and repeating the previous step.
+    :::tip
+    The output for `lsusb` should look something like this, with iPhone (or similar device) being an existing entry:
+    ```
+    Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+    Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+    Bus 001 Device 008: ID 05ac:12a8 Apple, Inc. iPhone 5/5C/5S/6/SE/7/8/X/XR
+    ```
+    The exact device name and bus/device numbers may vary, but they are not significant.
+    :::
+    9. Run the following command in the Terminal to allow iloader to be executable, and to launch iloader (ensure the filename matches what was downloaded):
+    ```
+    cd /mnt/chromeos/MyFiles/Downloads
+    chmod +x iloader-linux-aarch64.AppImage
+    ./iloader-linux-aarch64.AppImage
+    ```
   </TabItem>
 </Tabs>

--- a/docs/installation/prerequisites.mdx
+++ b/docs/installation/prerequisites.mdx
@@ -67,8 +67,8 @@ Now, follow the instructions to install [iloader](https://iloader.app) correspon
     2. Ensure all packages are updated by opening the Terminal, running the following command: `sudo apt-get update && sudo apt-get dist-upgrade`
     3. Open the Files app, right click on the `Downloads` folder in the left sidebar, and click `Share with Linux`. (It will be shared in `/mnt/chromeos/MyFiles/Downloads`)
     4. Download and install `usbmuxd` and `fuse`. You can install it with your package manager by running the following command in the Terminal: `sudo apt-get install usbmuxd fuse`
-    5. Download and install iloader. It is available as an [AppImage](https://github.com/nab138/iloader/releases/latest/download/iloader-linux-aarch64.AppImage). Download the file to your Downloads folder.
-    6. If `usbmuxd` isn't already started, run the following command in the Terminal: `sudo systemctl restart usbmuxd`
+    5. Download and install iloader. It is available as an AppImage. To know which version to download, determine your Chromebook's architecture using `uname -m`. If it reports x86_64, download the `amd64` version here: https://github.com/nab138/iloader/releases/download/v2.2.5/iloader-linux-amd64.AppImage. Otherwise if it reports `aarch64`, download the `aarch64` version here: https://github.com/nab138/iloader/releases/latest/download/iloader-linux-aarch64.AppImage. Download the file to your Downloads folder.
+    6. If `usbmuxd` isn't already started, run the following command in the Terminal: `sudo systemctl restart usbmuxd`.
     7. Navigate to `Manage USB devices` (in **Settings** -> **About ChromeOS** -> **Developers** -> **Linux development environment**), then connect your iPhone, iPad, or iPod touch (iDevice) to your Chromebook via a USB cable. As soon as you see the device, **quickly enable it from the list**. If you are prompted on your iDevice, trust the computer and enter your passcode.
     :::note
     **Enabling the iDevice __quickly__ in Manage USB devices is necessary** due to a bug with the `Linux development environment`. ChromeOS automatically claims the iDevice (which is why it appears in the Files app), preventing the Linux container from seeing it. Manually enabling it in **Manage USB devices** quickly before ChromeOS claims the iDevice will pass control to the container instead. You can follow **Step 8** to verify the container sees the iDevice.
@@ -83,11 +83,12 @@ Now, follow the instructions to install [iloader](https://iloader.app) correspon
     ```
     The exact device name and bus/device numbers may vary, but they are not significant.
     :::
-    9. Run the following command in the Terminal to allow iloader to be executable, and to launch iloader (ensure the filename matches what was downloaded):
+    9. Run the following command in the Terminal to allow iloader to be executable, and to launch iloader (ensure the filename matches what was downloaded, if it is `amd64`, replace `aarch64` with `amd64`):
     ```
     cd /mnt/chromeos/MyFiles/Downloads
     chmod +x iloader-linux-aarch64.AppImage
     ./iloader-linux-aarch64.AppImage
     ```
+    10. If iloader isn't showing your iDevice, you can try manually running `usbmuxd` by running the following commands in the Terminal **in another tab**: `sudo systemctl stop usbmuxd` and `sudo usbmuxd -v -f`. You may be prompted on your iDevice.
   </TabItem>
 </Tabs>


### PR DESCRIPTION
This adds another tab to include a guide for setting up iloader on a Chromebook. The install page may need to be changed as having the Chromebook recognize the iDevice is not as straight forward.

It requires Manage USB devices, and quickly enabling the iDevice as soon as it's plugged in, as Chromebook seems to currently have an issue where if the iDevice is enabled too late, the dev environment will not recognize it.

Currently this PR is a draft, but it is open to changes.