### PR TITLE
Add warning for issues relating to iLoader

### DIFF
--- a/docs/installation/install.mdx
+++ b/docs/installation/install.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 Before you start, make sure to download all software and complete all setup found in the [prerequisites page](prerequisites)!
 
 :::warning
-Support for issues relating to iloader, can be found at the [idevice Discord server](https://discord.gg/mACqxMxP3X), the SideStore server does not handle issues that occur from iLoader.
+Support for issues relating to iloader, can be found at the [idevice Discord server](https://discord.gg/mACqxMxP3X), the SideStore server does not handle issues that occur from iloader.
 :::
 
 ## Installing SideStore

--- a/docs/installation/install.mdx
+++ b/docs/installation/install.mdx
@@ -12,13 +12,13 @@ import TabItem from '@theme/TabItem';
 Before you start, make sure to download all software and complete all setup found in the [prerequisites page](prerequisites)!
 
 :::warning
-Support for issues relating to iLoader, can be found at the [iDevice Discord server](https://discord.gg/mACqxMxP3X), the SideStore server does not handle issues that occur from iLoader.
+Support for issues relating to iloader, can be found at the [idevice Discord server](https://discord.gg/mACqxMxP3X), the SideStore server does not handle issues that occur from iLoader.
 :::
 
 ## Installing SideStore
 ### On your computer
 1. Connect your iPhone, iPad, or iPod touch to your computer via a USB cable. If you are prompted, trust the computer and enter your passcode.
-2. Open iLoader.
+2. Open iloader.
 3. Sign in with your Apple Account. (It doesn't need to be the account associated with the device. Remember that it is case-sensitive!)
 4. Select your iPhone, iPad, or iPod touch.
 5. Select 'Install SideStore (Stable)'.

--- a/docs/installation/install.mdx
+++ b/docs/installation/install.mdx
@@ -11,10 +11,14 @@ import TabItem from '@theme/TabItem';
 
 Before you start, make sure to download all software and complete all setup found in the [prerequisites page](prerequisites)!
 
+:::warning
+Support for issues relating to iLoader, can be found at the [iDevice Discord server](https://discord.gg/mACqxMxP3X), the SideStore server does not handle issues that occur from iLoader.
+:::
+
 ## Installing SideStore
 ### On your computer
 1. Connect your iPhone, iPad, or iPod touch to your computer via a USB cable. If you are prompted, trust the computer and enter your passcode.
-2. Open iloader.
+2. Open iLoader.
 3. Sign in with your Apple Account. (It doesn't need to be the account associated with the device. Remember that it is case-sensitive!)
 4. Select your iPhone, iPad, or iPod touch.
 5. Select 'Install SideStore (Stable)'.


### PR DESCRIPTION
Adds a warning to redirect user to appropriate server (iDevice) to ask for support for iLoader, as the guide currently only links towards SideStore for support.